### PR TITLE
Change python-publish to only run when changes happen to package source code

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,10 @@ name: Upload Python Package
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - 'ect/**'
+      - 'setup.py'
+      - 'pyproject.toml'
 
 permissions:
   contents: read


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
python-publish workflow shouldn't run when source code doesn't change.

## Description
<!--- Describe your changes in detail -->
only runs on changes to `ect/`, `setup.py`, `pyproject.toml`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
allows branches to merge even if version number isn't bumped for non-package related changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (`make clean`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (`make html`)
- [ ] I have incremented the version number in the `pyproject.toml` file.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (`make tests`)
