### PR TITLE
update workflows to use uv

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -20,14 +19,25 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install teaspoon for testing
-      run: pip install .
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Create venv and install dependencies
+      run: |
+        uv venv
+        source .venv/bin/activate
+        uv pip install -e .
+
     - name: Run tests
-      run: make tests
+      run: |
+        source .venv/bin/activate
+        make tests
     # - name: Install dependencies
     #   run: |
     #     python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,21 +21,30 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+    
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
-    - name: Install dependencies
+        python-version-file: "pyproject.toml"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Create venv and install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install build
+        uv venv
+        source .venv/bin/activate
+        uv pip install build
+
     - name: Build package
-      run: python -m build
+      run: |
+        source .venv/bin/activate
+        python -m build
+
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
speed up build time for prs 
## Description
<!--- Describe your changes in detail -->
installs uv then runs everything using `uv pip install` instead for fast installation.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
build times for prs take a long time right now.
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of unit tests added, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
 `act -W .github/workflows/python-package.yml` and `act -W .github/workflows/python-publish.yml`


