### PR TITLE
Fix warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ect"
-version = "1.0.2"
+version = "1.0.3"
 authors = [
   { name="Liz Munch", email="muncheli@msu.edu" },
 ]

--- a/src/ect/ect_graph.py
+++ b/src/ect/ect_graph.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numba import prange, njit
+from numba.typed import List
 from typing import Optional, Union
 
 from .embed_cw import EmbeddedCW
@@ -145,7 +146,7 @@ class ECT:
         self, graph: Union[EmbeddedGraph, EmbeddedCW], directions
     ):
         """Compute projections of each simplex (vertices, edges, faces)"""
-        simplex_projections = []
+        simplex_projections = List()
         node_projections = self._compute_node_projections(
             graph.coord_matrix, directions
         )
@@ -187,7 +188,7 @@ class ECT:
         num_thresh = thresholds.shape[0]
         result = np.empty((num_dir, num_thresh), dtype=dtype)
 
-        sorted_projections = []
+        sorted_projections = List()
         for proj in simplex_projections_list:
             sorted_proj = np.empty_like(proj)
             for i in prange(num_dir):
@@ -197,7 +198,7 @@ class ECT:
         for j in prange(num_thresh):
             thresh = thresholds[j]
             for i in range(num_dir):
-                simplex_counts_list = []
+                simplex_counts_list = List()
                 for k in range(len(sorted_projections)):
                     projs = sorted_projections[k][:, i]
                     simplex_counts_list.append(

--- a/src/ect/ect_graph.py
+++ b/src/ect/ect_graph.py
@@ -55,8 +55,7 @@ class ECT:
         """Ensures directions is a valid Directions object of correct dimension"""
         if self.directions is None:
             if self.num_dirs is None:
-                raise ValueError(
-                    "Either 'directions' or 'num_dirs' must be provided.")
+                raise ValueError("Either 'directions' or 'num_dirs' must be provided.")
             self.directions = Directions.uniform(self.num_dirs, dim=graph_dim)
         elif isinstance(self.directions, list):
             # if list of vectors, convert to Directions object
@@ -127,12 +126,10 @@ class ECT:
 
         # override with theta if provided
         directions = (
-            self.directions if theta is None else Directions.from_angles([
-                                                                         theta])
+            self.directions if theta is None else Directions.from_angles([theta])
         )
 
-        simplex_projections = self._compute_simplex_projections(
-            graph, directions)
+        simplex_projections = self._compute_simplex_projections(graph, directions)
 
         ect_matrix = self._compute_directional_transform(
             simplex_projections, self.thresholds, self.shape_descriptor, self.dtype
@@ -162,11 +159,9 @@ class ECT:
 
         if isinstance(graph, EmbeddedCW) and len(graph.faces) > 0:
             node_to_index = {n: i for i, n in enumerate(graph.node_list)}
-            face_indices = [[node_to_index[v] for v in face]
-                            for face in graph.faces]
+            face_indices = [[node_to_index[v] for v in face] for face in graph.faces]
             face_maxes = np.array(
-                [np.max(node_projections[face, :], axis=0)
-                 for face in face_indices]
+                [np.max(node_projections[face, :], axis=0) for face in face_indices]
             )
             simplex_projections.append(face_maxes)
 
@@ -212,7 +207,7 @@ class ECT:
         return result
 
     @staticmethod
-    @njit(parallel=True, fastmath=True)
+    @njit(fastmath=True)
     def shape_descriptor(simplex_counts_list):
         """Calculate shape descriptor from simplex counts (Euler characteristic)"""
         chi = 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #50
## Description
<!--- Describe your changes in detail -->
removes parallel flag on `compute_shape_descriptor` since its just a simple function
and uses numba's list type to fix the deprecation warning on compile
```Encountered the use of a type that is scheduled for deprecation: type 'reflected list' found for argument 'simplex_projections_list' of function 'ECT._compute_directional_transform'.

For more information visit https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types

File "src/ect/ect_graph.py", line 172:
    @njit(parallel=True, fastmath=True)
    def _compute_directional_transform(
    ^

  warnings.warn(NumbaPendingDeprecationWarning(msg, loc=loc))
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
aesthetic
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of unit tests added, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
ect.calculate(g) runs without warnings
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project. (`make clean`)
- [ x] I have incremented the version number in the `pyproject.toml` file.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed. (`make tests`)
